### PR TITLE
Add tests for get page class

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@ program.
 
 TODO
 ====
-Setup Stuff
------------
-- pip package file
-- write toml file
-
 Features
 --------
 - CLI

--- a/src/selenium_page_stubber/cli.py
+++ b/src/selenium_page_stubber/cli.py
@@ -93,12 +93,12 @@ def cli(page_directory: pathlib.Path,
         site: str) -> None:
     """Stub out Page classes for each page in SITE."""
     driver = get_driver(site)
-    page_class = get_page_class(
+    new_page_class = get_page_class(
         page_directory=page_directory,
         page_module=page_module,
         page_class=page_class,
         template_directory=template_directory)
-    page = page_class(driver=driver, url=site)  # noqa: F841
+    page = new_page_class(driver=driver, url=site)  # noqa: F841
 
 
 if __name__ == "__main__":

--- a/src/selenium_page_stubber/pages/Page.py
+++ b/src/selenium_page_stubber/pages/Page.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, InitVar, KW_ONLY
+from dataclasses import dataclass, KW_ONLY
 from enum import StrEnum
 from typing import ClassVar, NamedTuple
 
@@ -28,9 +28,5 @@ class Page:
     locators: ClassVar[dict[str, Locator]]
 
     _: KW_ONLY
-    driver: InitVar[selenium.webdriver.chrome.webdriver.WebDriver]
-    url: InitVar[str]
-
-    def __init__(self, *, driver, url):
-        self.driver = driver
-        self.url = url
+    driver: selenium.webdriver.chrome.webdriver.WebDriver
+    url: str

--- a/src/selenium_page_stubber/pages/Page.py
+++ b/src/selenium_page_stubber/pages/Page.py
@@ -30,3 +30,7 @@ class Page:
     _: KW_ONLY
     driver: InitVar[selenium.webdriver.chrome.webdriver.WebDriver]
     url: InitVar[str]
+
+    def __init__(self, *, driver, url):
+        self.driver = driver
+        self.url = url

--- a/tests/selenium_page_stubber/test_cli.py
+++ b/tests/selenium_page_stubber/test_cli.py
@@ -3,6 +3,7 @@ import pathlib
 import unittest.mock
 
 
+import jinja2
 import pytest
 import requests
 
@@ -31,9 +32,9 @@ def test_get_driver_bad_url(caplog: pytest.LogCaptureFixture) -> None:
             unittest.mock.patch("requests.get", return_value=resp),
             caplog.at_level(logging.ERROR)):
         selenium_page_stubber.cli.get_driver(url)
-        assert [msg for msg in caplog.record_tuples if msg == (
-            "root", logging.ERROR,
-            f"{requests.codes.not_found} status when GETting {url}")]
+    assert [msg for msg in caplog.record_tuples if msg == (
+        "root", logging.ERROR,
+        f"{requests.codes.not_found} status when GETting {url}")]
 
 
 def test_get_page_class_base_class_on_parent(
@@ -82,6 +83,30 @@ def test_get_page_class_from_module(tmp_path: pathlib.Path) -> None:
     assert issubclass(new_page_class, selenium_page_stubber.pages.Page.Page)
 
 
+@pytest.mark.parametrize(
+    ["module_text", "error"], (
+        [")", SyntaxError],
+        ["5 / 0", ZeroDivisionError]
+    ))
+def test_get_page_class_from_module_error(
+        tmp_path: pathlib.Path,
+        module_text: str, error: Exception) -> None:
+    page_directory = tmp_path
+    page_module = "module"
+    page_class = "TestPage"
+    template_directory = pathlib.Path("template_directory")
+
+    with (page_directory / "{}.py".format(page_module)).open("w") as module:
+        module.write(module_text)
+
+    with pytest.raises(error):  # type: ignore[call-overload]
+        selenium_page_stubber.cli.get_page_class(
+            page_directory=page_directory,
+            page_module=page_module,
+            page_class=page_class,
+            template_directory=template_directory)
+
+
 def test_get_page_class_from_template(tmp_path: pathlib.Path) -> None:
     page_directory = pathlib.Path("path_directory")
     page_module = "module"
@@ -105,3 +130,26 @@ def test_get_page_class_from_template(tmp_path: pathlib.Path) -> None:
 
     assert new_page_class.__name__ == page_class
     assert issubclass(new_page_class, selenium_page_stubber.pages.Page.Page)
+
+
+@pytest.mark.parametrize(
+    ["template_text", "error"], (
+        ["{% if %}", jinja2.TemplateSyntaxError],
+        ["5 / 0", ZeroDivisionError]
+    ))
+def test_get_page_class_from_template_error(
+        tmp_path: pathlib.Path, template_text: str, error: Exception) -> None:
+    page_directory = pathlib.Path("path_directory")
+    page_module = "module"
+    page_class = "TestPage"
+    template_directory = tmp_path
+
+    with (template_directory / page_class).open("w") as template:
+        template.write(template_text)
+
+    with pytest.raises(error):  # type: ignore[call-overload]
+        selenium_page_stubber.cli.get_page_class(
+            page_directory=page_directory,
+            page_module=page_module,
+            page_class=page_class,
+            template_directory=template_directory)

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,8 @@ install_command = python3 -m pip install {opts} {packages}
 
 [testenv:execute]
 deps = -rrequirements.txt
-commands = selenium-page-stubber {posargs}
+commands =
+    selenium-page-stubber {posargs}
 
 
 [testenv:testing]
@@ -31,7 +32,7 @@ commands =
     python3 -m check_manifest -c
     python3 -m flake8 .
     python3 -m mypy --strict src tests
-    python3 -m coverage run -m pytest
+    python3 -m coverage run --source=src,tests -m pytest
     python3 -m coverage report
     python3 -m coverage annotate
 


### PR DESCRIPTION
- Cleaned up get_page_class to figure out what it's to do based on whether the module or template exist, rather than by catching exceptions.  This simplifies the code and testing, and allows the code to let exceptions in modules/templates propagate.
- Added tests for get_page_class, both happy and unhappy path
- Fix the Page dataclass to properly create the __init__ method
- Documentation fix