### PR TITLE
Simplify CLI and test that pages and templates directories have the right permissions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
 include tox.ini
 recursive-include tests *.py
+recursive-include src *.jinja

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ page modules.  Their names are supplied at the command line, and default to
 ```pages``` and ```templates```, respectively.  There will be one module that
 holds the base class for all page classes a tamplate for building a page class,
 which can be componentized, if necessary.  There will be one page class called
-HomePage.  This is the class that represents the initial site.  Any page can
+Page.  This is the class that is the parent to every Page stuff.  Any page can
 be modified manually after creation.
 
 Here is an example directory structure:
@@ -31,31 +31,25 @@ Here is an example directory structure:
 *Main selenium project*
 |
 |
+|
+|
+|
 |-------> pages/
+|       |
+|       |
+|       |-------> Page.py
+|       |
+|       |
+|       |-------> <any number of other Page modules, one for each page>
+|
+|
+|-------> templates/
         |
         |
-        |-------> pages/
-        |       |
-        |       |
-        |       |-------> BasePage.py
-        |       |
-        |       |
-        |       |-------> HomePage.py
-        |       |
-        |       |
-        |       |-------> lib.py <utility functions used by the pages>
-        |       |
-        |       |
-        |       |-------> <any number of other Page modules, one for each page>
+        |-------> Page.jinja <template used to build pages>
         |
         |
-        |-------> templates/
-                |
-                |
-                |-------> Page.jinja <template used to build pages>
-                |
-                |
-                |-------> <any number of other templates, which can be used by Page.jinja
+        |-------> <any number of other templates, which can be used by Page.jinja
         
 #Development
 

--- a/src/selenium_page_stubber/cli.py
+++ b/src/selenium_page_stubber/cli.py
@@ -1,5 +1,7 @@
+import os
 import os.path
 import pathlib
+import tempfile
 
 
 import click
@@ -10,12 +12,53 @@ import selenium_page_stubber.client.lib
 import selenium_page_stubber.user
 
 
-def stub_pages_main(
+def check_directory_permissions(
+        pages_dir: pathlib.Path = pathlib.Path("pages"),
+        templates_dir: pathlib.Path = pathlib.Path("templates")) -> None:
+    for directory in (pages_dir, templates_dir):
+        # Check if the directory is executable by cd'ing into it
+        current = os.getcwd()
+        os.chdir(str(directory))
+        os.chdir(current)
+
+        # Check if the directory is readable by listing its contents
+        list(directory.iterdir())
+
+        # Check if the directory is writable by creating a temporary file
+        with tempfile.TemporaryFile(dir=str(directory.resolve())):
+            pass
+
+
+def check_file_permissions(
+        base_page_module_file: pathlib.Path = pathlib.Path("pages/Page.py"),
+        base_template_file: pathlib.Path = pathlib.Path("templates/Page.jinja")) -> None:  # noqa: E501
+    for file in (base_page_module_file, base_template_file):
+        # Check if the file is readable by reading it
+        file.read_text()
+
+        # Check if the file is writable by opening it in write mode
+        with file.open(mode="w"):
+            pass
+
+
+def check_permissions(
+        pages_dir: pathlib.Path = pathlib.Path("pages"),
+        templates_dir: pathlib.Path = pathlib.Path("templates"),
+        base_page_module_file: pathlib.Path = pathlib.Path("Page.py"),
+        base_template_file: pathlib.Path = pathlib.Path("Page.jinja")) -> None:
+    check_directory_permissions(
+        pages_dir=pages_dir,
+        templates_dir=templates_dir)
+    check_file_permissions(
+        base_page_module_file=pages_dir / base_page_module_file,
+        base_template_file=templates_dir / base_template_file)
+
+
+def main(
         site: str,
         page_directory: pathlib.Path,
         template_directory: pathlib.Path,
         template_name: str,
-        output_directory: pathlib.Path,
         page_class: str,
         page_module: str) -> None:
     driver = selenium_page_stubber.client.lib.get_driver(site)
@@ -28,110 +71,41 @@ def stub_pages_main(
     page = new_page_class(driver=driver, url=site)  # noqa: F841
 
 
-@click.group(context_settings={"auto_envvar_prefix": "SPS"})
+@click.command
 @click.option(
-    "page_directory", "--page-directory", default="pages",
-    type=click.Path(
-        path_type=pathlib.Path, file_okay=False,
-        readable=True, executable=True),
-    help="The path to the directory where the Page modules are")
-@click.option(
-    "page_module", "--page-module", default="Page",
-    help="The module the base page class is in")
-@click.option(
-    "page_class", "--page-class", default="Page",
-    help="The name of the base Page class")
-@click.option(
-    "template_directory", "--template-directory",
-    type=click.Path(
-        path_type=pathlib.Path, file_okay=False,
-        readable=True, executable=True),
-    default="templates",
-    help="The path to the Jinja apps for building the pages.")
-@click.option(
-    "template_name", "--template-name",
-    help=("The name of the jinja template for building pages.  "
-          "Defaults to <page_module>.jinja"))
-@click.pass_context
-def cli(ctx: click.Context,
-        page_directory: pathlib.Path,
-        page_module: str,
-        page_class: str,
-        template_directory: pathlib.Path,
-        template_name: str | None) -> None:
-    """Stub out Page classes for each page in SITE."""
-    ctx.ensure_object(dict)
-
-    template_name = template_name if template_name else f"{page_module}.jinja"
-    ctx.obj.update({
-        "page_directory": page_directory,
-        "page_module": page_module,
-        "page_class": page_class,
-        "template_directory": template_directory,
-        "template_name": template_name})
-
-
-@cli.command()
-@click.option(
-    "output_directory", "--output-directory",
-    type=click.Path(
-        path_type=pathlib.Path, file_okay=False, readable=True,
-        executable=True, writable=True),
-    default="",
-    help=("The directory where the output files will be placed.  "
-          "Defaults to <page_directory>"))
+    "initialize", "--initialize", is_flag=True,
+    envvar="INITIALIZE",
+    help="Initialize pages and templates directory before creating pages")
 @click.argument("site")
 @click.pass_context
-def stub_pages(
-        ctx: click.Context,
-        output_directory: pathlib.Path,
+def cli(ctx: click.Context,
+        initialize: bool,
         site: str) -> None:
-    """Create the stub Selenium pages."""
-    ctx.ensure_object(dict)
-    ctx.obj["output_directory"] = (
-        ctx.obj["page_directory"]
-        if output_directory == pathlib.Path("")
-        else output_directory)
+    """Create the stub Selenium page."""
+    pages_dir = pathlib.Path("pages")
+    base_page_name = "Page"
+    base_page_module_name = "Page"
+    templates_dir = pathlib.Path("templates")
+    base_template_file = "{}.jinja".format(base_page_module_name)
+    if initialize:
+        user_dir = pathlib.Path(
+            os.path.split(selenium_page_stubber.user.__file__)[0])
+        selenium_page_stubber.client.lib.initialize(
+            pages_src=user_dir / pages_dir,
+            pages_target=pages_dir,
+            templates_src=user_dir / templates_dir,
+            templates_target=templates_dir)
 
-    page_directory = ctx.obj["page_directory"]
-    page_module = ctx.obj["page_module"]
-    template_directory = ctx.obj["template_directory"]
-    template_name = ctx.obj["template_name"]
-
-    # verify base page module is readable
-    page_module_file = page_directory / "{}.py".format(
-        page_module)
     try:
-        page_module_file.read_text()
-    except PermissionError:
-        click.echo(f"'{page_module_file}' is not readable", err=True)
-        ctx.exit(2)
-    except FileNotFoundError:
-        click.echo(f"'{page_module_file}' does not exist", err=True)
-        ctx.exit(2)
+        check_permissions()
+    except Exception as exc:
+        click.echo(str(exc))
+        raise
 
-    # verify the base template is readable
-    template_file = template_directory / template_name
-    try:
-        template_file.read_text()
-    except PermissionError:
-        click.echo(f"'{template_file}' is not readable", err=True)
-        ctx.exit(2)
-    except FileNotFoundError:
-        click.echo(f"'{template_file}' does not exist", err=True)
-        ctx.exit(2)
-    ctx.obj['site'] = site
-    stub_pages_main(**ctx.obj)
-
-
-@cli.command()
-@click.pass_context
-def initialize(ctx: click.Context) -> None:
-    """Initialize the page and template directories"""
-    user_dir = pathlib.Path(
-        os.path.split(selenium_page_stubber.user.__file__)[0])
-    selenium_page_stubber.client.lib.initialize(
-        pages_src=user_dir / "pages",
-        pages_target=ctx.obj["page_directory"],
-        templates_src=user_dir / "templates",
-        templates_target=ctx.obj["template_directory"])
+    main(
+        site,
+        pages_dir,
+        templates_dir,
+        base_template_file,
+        base_page_name,
+        base_page_module_name)

--- a/src/selenium_page_stubber/client/lib.py
+++ b/src/selenium_page_stubber/client/lib.py
@@ -78,6 +78,7 @@ def copy_with_possible_suffix(
             target.write_text(data)
     except FileNotFoundError:
         target.write_text(data)
+    target.chmod(0o666)
 
 
 def initialize(
@@ -87,8 +88,8 @@ def initialize(
         templates_target: pathlib.Path) -> None:
     """Create page_directory and template_directory, if necessary, then copy
     everything over from the "user" directories."""
-    pages_target.mkdir(exist_ok=True)
-    templates_target.mkdir(exist_ok=True)
+    pages_target.mkdir(exist_ok=True, mode=0o777)
+    templates_target.mkdir(exist_ok=True, mode=0o777)
 
     for f in pages_src.iterdir():
         if f.is_file():

--- a/tests/selenium_page_stubber/test_cli.py
+++ b/tests/selenium_page_stubber/test_cli.py
@@ -1,9 +1,9 @@
 import os
 import pathlib
-from typing import cast
 import unittest.mock
 
 
+import click.globals
 import click.testing
 import pytest
 
@@ -14,23 +14,21 @@ import selenium_page_stubber.user
 
 @unittest.mock.patch("selenium_page_stubber.client.lib.get_page_class")
 @unittest.mock.patch("selenium_page_stubber.client.lib.get_driver")
-def test_stub_pages_main(
+def test_main(
         mock_get_driver: unittest.mock.MagicMock,
         mock_get_page_class: unittest.mock.MagicMock) -> None:
     site = "https://www.site.com"
     page_directory = pathlib.Path("page_directory")
     template_directory = pathlib.Path("template_directory")
     template_name = "template_name"
-    output_directory = pathlib.Path("output_directory")
     page_class = "PageClass"
     page_module = "PageModule"
 
-    selenium_page_stubber.cli.stub_pages_main(
+    selenium_page_stubber.cli.main(
         site=site,
         page_directory=page_directory,
         template_directory=template_directory,
         template_name=template_name,
-        output_directory=output_directory,
         page_class=page_class,
         page_module=page_module)
     mock_get_driver.assert_called_once_with(site)
@@ -45,377 +43,133 @@ def test_stub_pages_main(
         url=site)
 
 
-@pytest.mark.parametrize(
-    ["options", "expected_result", "expected_output"], (
-        # Directories con't exist as files
-        (["--page-directory", "file",
-          "--template-directory", "directory",
-          "--output-directory", "directory"], 2,
-          "Invalid value for '--page-directory': Directory 'file' is a file"),  # noqa: E501
-        (["--page-directory", "directory",
-          "--template-directory", "file",
-          "--output-directory", "directory"], 2,
-          "Invalid value for '--template-directory': Directory 'file' is a file"),  # noqa: E501
-        (["--page-directory", "directory",
-          "--template-directory", "directory",
-          "--output-directory", "file"], 2,
-          "Invalid value for '--output-directory': Directory 'file' is a file"),  # noqa: E501
-
-        # Directories have to be readable
-        (["--page-directory", "non-readable",
-          "--template-directory", "directory",
-          "--output-directory", "directory"], 2,
-          "Invalid value for '--page-directory': Directory 'non-readable' is not readable"),  # noqa: E501
-        (["--page-directory", "directory",
-          "--template-directory", "non-readable",
-          "--output-directory", "directory"], 2,
-          "Invalid value for '--template-directory': Directory 'non-readable' is not readable"),  # noqa: E501
-        (["--page-directory", "directory",
-          "--template-directory", "directory",
-          "--output-directory", "non-readable"], 2,
-          "Invalid value for '--output-directory': Directory 'non-readable' is not readable"),  # noqa: E501
-
-        # Directories have to be executable
-        (["--page-directory", "non-executable",
-          "--template-directory", "directory",
-          "--output-directory", "directory"], 2,
-          "Invalid value for '--page-directory': Directory 'non-executable' is not executable"),  # noqa: E501
-        (["--page-directory", "directory",
-          "--template-directory", "non-executable",
-          "--output-directory", "directory"], 2,
-          "Invalid value for '--template-directory': Directory 'non-executable' is not executable"),  # noqa: E501
-        (["--page-directory", "directory",
-          "--template-directory", "directory",
-          "--output-directory", "non-executable"], 2,
-          "Invalid value for '--output-directory': Directory 'non-executable' is not executable"),  # noqa: E501
-
-        # Output has to be writable
-        (["--page-directory", "non-writable",
-          "--template-directory", "directory",
-          "--output-directory", "directory"], 0, ""),
-        (["--page-directory", "directory",
-          "--template-directory", "non-writable",
-          "--output-directory", "directory"], 0, ""),
-        (["--page-directory", "directory",
-          "--template-directory", "directory",
-          "--output-directory", "non-writable"], 2,
-          "Invalid value for '--output-directory': Directory 'non-writable' is not writable"),  # noqa: E501
-
-        # Provided a non-writable to both page and output, will fail on output
-        (["--page-directory", "non-writable",
-          "--template-directory", "directory",
-          "--output-directory", "non-writable"], 2,
-          "Invalid value for '--output-directory': Directory 'non-writable' is not writable"),  # noqa: E501
-    ))
-@unittest.mock.patch("selenium_page_stubber.cli.stub_pages_main")
-def test_cli_paths(
-        mock_stub_pages_main: unittest.mock.MagicMock,
-        options: list[str],
-        expected_result: int,
-        expected_output: str,
-        tmp_path: pathlib.Path) -> None:
-    """Verify the directory options do the appropriate checks."""
-    # Create file structure
-    directories = dict(
-        (name, tmp_path / name)
-        for name in [
-            "directory", "non-readable", "non-writable", "non-executable"])
-    for directory in directories.values():
-        directory.mkdir()
-        (directory / "Page.py").touch()
-        (directory / "Page.jinja").touch()
-    directories["non-readable"].chmod(0o300)
-    directories["non-executable"].chmod(0o600)
-    directories["non-writable"].chmod(0o500)
-    (tmp_path / "file").touch()
-    os.chdir(str(tmp_path.resolve()))
-
-    try:
-        # Test variables
-        site = "https://www.site.com"
-        runner = click.testing.CliRunner()
-
-        runner_args = options[:4] + ["stub-pages"] + options[4:] + [site]
-        result = runner.invoke(
-            selenium_page_stubber.cli.cli,
-            runner_args)
-        assert result.exit_code == expected_result
-        assert expected_output in result.output
-        if expected_result == 0:
-            # The command succeeded and was supposed to,
-            # verify the right stuff was passed to main()
-            arguments: dict[str, str | pathlib.Path] = {
-                "site": site,
-                "page_module": "Page",
-                "page_class": "Page",
-                "template_name": "Page.jinja"
-            }
-            update_args = dict(
-                (option[2:].replace("-", "_"), pathlib.Path(value))
-                for (option, value) in zip(
-                    options[0:len(options):2], options[1:len(options):2]))
-            arguments.update(update_args)
-            mock_stub_pages_main.assert_called_once_with(**arguments)
-    finally:
-        os.chdir("..")
-        (tmp_path / "file").chmod(0o777)
-        (tmp_path / "directory").chmod(0o777)
-        (tmp_path / "non-readable").chmod(0o777)
-        (tmp_path / "non-writable").chmod(0o777)
-        (tmp_path / "non-executable").chmod(0o777)
-
-
-@unittest.mock.patch("selenium_page_stubber.cli.stub_pages_main")
-@unittest.mock.patch("pathlib.Path.read_text")
-def test_output_directory_and_template_name(
-        mock_read_text: unittest.mock.MagicMock,
-        mock_stub_pages_main: unittest.mock.MagicMock,
-        tmp_path: pathlib.Path) -> None:
-    """Verify that output_directory is the same as the page_directory if it
-    isn't supplied.
-    """
-    inputs: dict[str, str | pathlib.Path] = {
-        "site": "site",
-        "page_directory": pathlib.Path("pages"),
-        "template_directory": pathlib.Path("templates"),
-        "page_class": "Page",
-        "page_module": "Page"
-    }
-    os.chdir(str(tmp_path.resolve()))
-    cast(pathlib.Path, inputs["page_directory"]).mkdir()
-    cast(pathlib.Path, inputs["template_directory"]).mkdir()
-    pathlib.Path("other_page_directory").mkdir()
-    runner = click.testing.CliRunner()
-
-    # If we pass in defaults, output_directory will be "pages" and
-    # template_name will be Page.jinja
-    runner.invoke(selenium_page_stubber.cli.cli, ["stub-pages", "site"])
-    defaults = {
-        "output_directory": inputs["page_directory"],
-        "template_name": "{}.jinja".format(inputs["page_module"])}
-    defaults.update(inputs)
-    mock_stub_pages_main.assert_called_once_with(**defaults)
-    mock_stub_pages_main.reset_mock()
-
-    # If we pass in a value for page_directory and page_module and none for
-    # output_directory or template_name, output_directory will match
-    # page_directory and template_name will be <page_module>.jinja
-    modified_page_stuff = dict(inputs)
-    modified_page_stuff.update({
-        "page_directory": pathlib.Path("other_page_directory"),
-        "page_module": "other_page_module",
-        "output_directory": pathlib.Path("other_page_directory"),
-        "template_name": "other_page_module.jinja"})
-    runner.invoke(selenium_page_stubber.cli.cli, [
-        "--page-directory", str(modified_page_stuff["page_directory"]),
-        "--page-module", "other_page_module",
-        "stub-pages", "site"])
-    mock_stub_pages_main.assert_called_once_with(**modified_page_stuff)
-    mock_stub_pages_main.reset_mock()
-
-    # If we pass in a value for output_directory and template_name
-    # output_directory and template_name will match what we pass in
-    temporary_directory = cast(pathlib.Path, inputs["template_directory"])
-    (temporary_directory / "template_name.jinja").touch()
-    new_values = dict(inputs)
-    new_values.update({
-        "output_directory": pathlib.Path("new_output_directory"),
-        "template_name": "template_name.jinja"})
-    runner.invoke(selenium_page_stubber.cli.cli, [
-        "--template-name", str(new_values["template_name"]),
-        "stub-pages",
-        "--output-directory", str(new_values["output_directory"]),
-        "site"])
-    mock_stub_pages_main.assert_called_once_with(**new_values)
-
-
-@unittest.mock.patch("selenium_page_stubber.cli.stub_pages_main")
-def test_module_path_checking(
-        mock_stub_pages_main: unittest.mock.MagicMock,
-        tmp_path: pathlib.Path) -> None:
-    """Verify the base page module checking."""
-    site = "https://www.site.com"
-    page_directory = "pages"
-    template_directory = "templates"
-    template_name = "template_name.jinja"
-    output_directory = page_directory
-    page_module = "Page"
-    page_class = "Page"
-    module_path = (
-        tmp_path / page_directory / "{}.py".format(page_module)).resolve()
-    template_path = (
-        tmp_path / template_directory / template_name).resolve()
-    (tmp_path / page_directory).mkdir()
-    (tmp_path / template_directory).mkdir()
-    template_path.touch()
-
-    os.chdir(str(tmp_path.resolve()))
-    runner = click.testing.CliRunner()
-
-    # If the module doesn't exist
-    result = runner.invoke(
-        selenium_page_stubber.cli.cli,
-        ["--page-directory", page_directory,
-         "--page-class", page_class,
-         "--page-module", page_module,
-         "--template-directory", template_directory,
-         "--template-name", template_name,
-         "stub-pages", "--output-directory", output_directory, site])
-    assert result.exit_code == 2
-    assert "'pages/Page.py' does not exist" in result.output
-
-    # If the module exists, but isn't readable
-    module_path.touch(mode=0o300)
-    try:
-        result = runner.invoke(
-            selenium_page_stubber.cli.cli,
-            ["--page-directory", page_directory,
-             "--page-class", page_class,
-             "--page-module", page_module,
-             "--template-directory", template_directory,
-             "--template-name", template_name,
-             "stub-pages", "--output-directory", output_directory, site])
-        assert result.exit_code == 2
-        assert "'pages/Page.py' is not readable" in result.output
-    finally:
-        module_path.chmod(0o777)
-
-    # If the module exists and is readable
-    result = runner.invoke(
-        selenium_page_stubber.cli.cli,
-        ["--page-directory", page_directory,
-         "--page-class", page_class,
-         "--page-module", page_module,
-         "--template-directory", template_directory,
-         "--template-name", template_name,
-         "stub-pages", "--output-directory", output_directory, site])
-    assert result.exit_code == 0
-    mock_stub_pages_main.assert_called()
-
-
-@unittest.mock.patch("selenium_page_stubber.cli.stub_pages_main")
-def test_template_path_checking(
-        mock_stub_pages_main: unittest.mock.MagicMock,
-        tmp_path: pathlib.Path) -> None:
-    """Verify the base page module checking."""
-    site = "https://www.site.com"
-    page_directory = "pages"
-    template_directory = "templates"
-    template_name = "template_name.jinja"
-    output_directory = page_directory
-    page_module = "Page"
-    page_class = "Page"
-    module_path = (
-        tmp_path / page_directory / "{}.py".format(page_module)).resolve()
-    template_path = (
-        tmp_path / template_directory / template_name).resolve()
-    (tmp_path / page_directory).mkdir()
-    (tmp_path / template_directory).mkdir()
-    module_path.touch()
-
-    os.chdir(str(tmp_path.resolve()))
-    runner = click.testing.CliRunner()
-
-    # If the template doesn't exist
-    result = runner.invoke(
-        selenium_page_stubber.cli.cli,
-        ["--page-directory", page_directory,
-         "--page-class", page_class,
-         "--page-module", page_module,
-         "--template-directory", template_directory,
-         "--template-name", template_name,
-         "stub-pages", "--output-directory", output_directory, site])
-    assert result.exit_code == 2
-    assert "'templates/template_name.jinja' does not exist" in result.output
-
-    # If the template exists, but isn't readable
-    template_path.touch(mode=0o300)
-    try:
-        result = runner.invoke(
-            selenium_page_stubber.cli.cli,
-            ["--page-directory", page_directory,
-             "--page-class", page_class,
-             "--page-module", page_module,
-             "--template-directory", template_directory,
-             "--template-name", template_name,
-             "stub-pages", "--output-directory", output_directory, site])
-        assert result.exit_code == 2
-        assert "'templates/template_name.jinja' is not readable" in result.output  # noqa: E501
-    finally:
-        template_path.chmod(0o777)
-
-    # If the module exists and is readable
-    result = runner.invoke(
-        selenium_page_stubber.cli.cli,
-        ["--page-directory", page_directory,
-         "--page-class", page_class,
-         "--page-module", page_module,
-         "--template-directory", template_directory,
-         "--template-name", template_name,
-         "stub-pages", "--output-directory", output_directory, site])
-    assert result.exit_code == 0
-    mock_stub_pages_main.assert_called()
-
-
-@unittest.mock.patch("pathlib.Path.read_text")
-@unittest.mock.patch("selenium_page_stubber.cli.stub_pages_main")
-def test_environment_variables(
-        mock_stub_pages_main: unittest.mock.MagicMock,
-        mock_read_text: unittest.mock.MagicMock,
+@pytest.mark.parametrize("set_flag", (True, False))
+@unittest.mock.patch(
+    "selenium_page_stubber.client.lib.initialize",
+    wraps=selenium_page_stubber.client.lib.initialize)
+@unittest.mock.patch("selenium_page_stubber.cli.main")
+def test_cli_initialize(
+        mock_main: unittest.mock.MagicMock,
+        spy_initialize: unittest.mock.MagicMock,
+        set_flag: bool,
         tmp_path: pathlib.Path,
         monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify that we can get the options from environment variables"""
-    page_module = "page_module"
-    page_class = "page_class"
-    template_name = "template_name"
+    """Verify that we can initialize based on environment and the flag"""
     site = "https://www.site.com"
-    tmp_path_resolved = tmp_path.resolve()
-    monkeypatch.setenv("SPS_PAGE_DIRECTORY", str(tmp_path_resolved))
-    monkeypatch.setenv("SPS_PAGE_MODULE", page_module)
-    monkeypatch.setenv("SPS_PAGE_CLASS", page_class)
-    monkeypatch.setenv("SPS_TEMPLATE_DIRECTORY", str(tmp_path_resolved))
-    monkeypatch.setenv("SPS_TEMPLATE_NAME", template_name)
-    monkeypatch.setenv("SPS_OUTPUT_DIRECTORY", str(tmp_path_resolved))
+    arguments = [site]
     runner = click.testing.CliRunner()
 
-    result = runner.invoke(selenium_page_stubber.cli.cli, ["stub-pages", site])
-    assert result.exit_code == 0
-    mock_stub_pages_main.assert_called_with(**{
-        "page_directory": tmp_path_resolved,
-        "page_module": page_module,
-        "page_class": page_class,
-        "template_directory": tmp_path_resolved,
-        "template_name": template_name,
-        "output_directory": tmp_path_resolved,
-        "site": site})
+    if set_flag:
+        arguments = ["--initialize"] + arguments
+    else:
+        monkeypatch.setenv("INITIALIZE", "True")
+
+    os.chdir(str(tmp_path))
+    try:
+        result = runner.invoke(
+            selenium_page_stubber.cli.cli, arguments)
+        assert result.exit_code == 0
+        spy_initialize.assert_called()
+        mock_main.assert_called()
+    finally:
+        os.chdir("..")
+        for (dirpath, dirnames, filenames) in tmp_path.walk(top_down=False):
+            for entry in filenames + dirnames:
+                entry_path = (dirpath / entry)
+                entry_path.chmod(777)
+                if entry_path.is_file():
+                    entry_path.unlink()
+                else:
+                    entry_path.rmdir()
 
 
-@unittest.mock.patch("pathlib.Path.read_text")
-@unittest.mock.patch("selenium_page_stubber.client.lib.initialize")
-def test_initialize(
-        mock_initialize: unittest.mock.MagicMock,
-        mock_read_text: unittest.mock.MagicMock,
-        tmp_path: pathlib.Path) -> None:
-    """Verify initialize subcommand cli works"""
-    page_module = "page_module"
-    page_class = "page_class"
-    template_name = "template_name"
-    tmp_path_resolved = tmp_path.resolve()
-    user_dir = pathlib.Path(
-        os.path.split(selenium_page_stubber.user.__file__)[0])
+@unittest.mock.patch("os.chdir")
+@unittest.mock.patch("tempfile.TemporaryFile")
+def test_check_directory_permissions(
+        mock_tempfile: unittest.mock.MagicMock,
+        mock_chdir: unittest.mock.MagicMock) -> None:
+    class TestPath(pathlib.Path):
+        pass
+
+    directories = {
+        "pages_dir": TestPath("pages"),
+        "templates_dir": TestPath("templates")
+    }
+
+    for directory, path in directories.items():
+        path.iterdir = unittest.mock.MagicMock()  # type: ignore[method-assign]
+        path.resolve = unittest.mock.MagicMock(return_value=path)  # type: ignore[method-assign] # noqa: E501
+
+    selenium_page_stubber.cli.check_directory_permissions(**directories)
+
+    for path in directories.values():
+        # Execution privileges were checked
+        mock_chdir.assert_any_call(str(path))
+
+        # Read privileges were checked
+        path.iterdir.assert_called()  # type: ignore[attr-defined]
+
+        # Write privilegest were checked
+        mock_tempfile.assert_any_call(dir=str(path))
+
+
+def test_check_file_permissions() -> None:
+    class TestPath(pathlib.Path):
+        pass
+
+    pages = {
+        "base_page_module_file": TestPath("Page.py"),
+        "base_template_file": TestPath("Page.jinja"),
+    }
+
+    for page, path in pages.items():
+        path.read_text = unittest.mock.MagicMock()  # type: ignore[method-assign] # noqa: E501
+        path.open = unittest.mock.MagicMock()  # type: ignore[method-assign]
+
+    selenium_page_stubber.cli.check_file_permissions(**pages)
+
+    for path in pages.values():
+        # Read privileges were checked
+        path.read_text.assert_called()  # type: ignore[attr-defined]
+
+        # Write privileges were checked
+        path.open.assert_any_call(mode="w")  # type: ignore[attr-defined]
+
+
+@unittest.mock.patch("selenium_page_stubber.cli.check_directory_permissions")
+@unittest.mock.patch("selenium_page_stubber.cli.check_file_permissions")
+def test_check_permissions(
+        mock_check_file_permissions: unittest.mock.MagicMock,
+        mock_check_directory_permissions: unittest.mock.MagicMock) -> None:
+    directories = {
+        "pages_dir": pathlib.Path("pages"),
+        "templates_dir": pathlib.Path("templates")
+    }
+    files = {
+        "base_page_module_file": pathlib.Path("Page.py"),
+        "base_template_file": pathlib.Path("Page.jinja")
+    }
+    arguments = dict(files)
+    arguments.update(directories)
+
+    selenium_page_stubber.cli.check_permissions(**arguments)
+    mock_check_directory_permissions.assert_called_once_with(**directories)
+    mock_check_file_permissions.assert_called_once_with(**{
+        "base_page_module_file": (
+            directories["pages_dir"] / files["base_page_module_file"]),
+        "base_template_file": (
+            directories["templates_dir"] / files["base_template_file"])})
+
+
+@unittest.mock.patch(
+    "selenium_page_stubber.cli.check_permissions",
+    side_effect=Exception("Error"))
+@unittest.mock.patch("selenium_page_stubber.cli.main")
+def test_cli_failed_permissions(
+        mock_main: unittest.mock.MagicMock,
+        mock_check_permissions: unittest.mock.MagicMock) -> None:
     runner = click.testing.CliRunner()
-
     result = runner.invoke(
-        selenium_page_stubber.cli.cli,
-        ["--page-directory", str(tmp_path_resolved / "pages"),
-         "--page-module", page_module,
-         "--page-class", page_class,
-         "--template-name", template_name,
-         "--template-directory", str(
-             tmp_path_resolved / "templates"), "initialize"])
-    assert result.exit_code == 0
-    mock_initialize.assert_called_with(**{
-        "pages_src": user_dir / "pages",
-        "pages_target": tmp_path / "pages",
-        "templates_src": user_dir / "templates",
-        "templates_target": tmp_path / "templates"})
+        selenium_page_stubber.cli.cli, ["https://www.site.com"])
+    assert result.exit_code == 1
+    assert result.output.strip() == "Error"


### PR DESCRIPTION
* The CLI is:  ```selenium_page_stubber [--initialize] site```.  The initialize flag tells whether to create the ```pages``` and ```templates``` before scanning the site.
* Before scanning, verify that the ```pages``` and ```templates``` directories, and contents, have the right permissions
* Lots of tests.